### PR TITLE
Heltecv3

### DIFF
--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -74,6 +74,44 @@ build_flags =
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=4
 	-D OLED_SCL=15
+[env_heltecv2]
+build_flags =
+	-D SERIAL_PIN_TX=23
+	-D SERIAL_PIN_RX=17
+	; LoRa Config
+	-D LORA_PIN_SCK=5
+	-D LORA_PIN_MISO=19
+	-D LORA_PIN_MOSI=27
+	-D LORA_PIN_CS=18
+	-D LORA_PIN_RST=14
+	-D LORA_PIN_DIO0=26
+	-D LORA_POWER=21	; also controls OLED power, low enable
+	; Human Interface
+	-D PIN_BUTTON=0
+	-D IO_LED_PIN=25
+	-D HAS_OLED
+	-D OLED_ADDRESS=0x3c
+	-D OLED_SDA=4
+	-D OLED_SCL=15
+[env_heltecv3]
+build_flags =
+	-D SERIAL_PIN_TX=43
+	-D SERIAL_PIN_RX=44
+	; LoRa Config
+	-D LORA_PIN_SCK=9
+	-D LORA_PIN_MISO=11
+	-D LORA_PIN_MOSI=10
+	-D LORA_PIN_CS=8
+	-D LORA_PIN_RST=12
+	-D LORA_PIN_DIO0=13
+	-D LORA_POWER=36	; only controls OLED power, low enable
+	; Human Interface
+	-D PIN_BUTTON=0
+	-D IO_LED_PIN=35
+	-D HAS_OLED
+	-D OLED_ADDRESS=0x3c
+	-D OLED_SDA=17
+	-D OLED_SCL=18
 
 
 [env:diy_LoRa_lilygo10_433_via_UART]
@@ -183,3 +221,21 @@ build_flags =
 	${env_lilygo20.build_flags}
 	'-D CFG_TARGET_NAME="LL20"'
 	'-D CFG_TARGET_FULLNAME="Lilygo v2.0 915MHz"'
+
+[env:diy_LoRa_heltecv2_433_via_UART]
+extends = env_common_esp32, env_common_433, env_heltecv2
+build_flags = 
+	${env_common_esp32.build_flags}
+	${env_common_433.build_flags}
+	${env_heltecv2.build_flags}
+	'-D CFG_TARGET_NAME="HTv2"'
+	'-D CFG_TARGET_FULLNAME="Heltec v2 433MHz"'
+
+[env:diy_LoRa_heltecv3_433_via_UART]
+extends = env_common_esp32, env_common_433, env_heltecv3
+build_flags = 
+	${env_common_esp32.build_flags}
+	${env_common_433.build_flags}
+	${env_heltecv3.build_flags}
+	'-D CFG_TARGET_NAME="HTv3"'
+	'-D CFG_TARGET_FULLNAME="Heltec v3 433MHz"'

--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -85,7 +85,7 @@ build_flags =
 	-D LORA_PIN_CS=18
 	-D LORA_PIN_RST=14
 	-D LORA_PIN_DIO0=26
-	-D LORA_POWER=21	; also controls OLED power, low enable
+	-D LORA_POWER=10
 	; Human Interface
 	-D PIN_BUTTON=0
 	-D IO_LED_PIN=25
@@ -103,8 +103,8 @@ build_flags =
 	-D LORA_PIN_MOSI=10
 	-D LORA_PIN_CS=8
 	-D LORA_PIN_RST=12
-	-D LORA_PIN_DIO0=13
-	-D LORA_POWER=36	; only controls OLED power, low enable
+	-D LORA_PIN_DIO0=14
+	-D LORA_POWER=10
 	; Human Interface
 	-D PIN_BUTTON=0
 	-D IO_LED_PIN=35


### PR DESCRIPTION
create targets as found for Heltec boards:
V2 https://resource.heltec.cn/download/WiFi_LoRa_32/V2/WiFi_LoRa_32_V2(433%2C470-510).PDF
V3 https://resource.heltec.cn/download/WiFi_LoRa32_V3/HTIT-WB32LA(F)_V3_Schematic_Diagram.pdf

cant figure out what LORA_POWER = 10 is for, but looks like all targets leave this alone.